### PR TITLE
add call to endGenerateDocumentation at end of docs generation

### DIFF
--- a/lib/scripts/gen-docs.js
+++ b/lib/scripts/gen-docs.js
@@ -865,6 +865,9 @@ var generate = function (options_in, callBack) {
         //generate information on the groups for the UI
         generateGroupManifest(groups);
 
+        // SP: bugfix - this fires the callback 
+        endGenerateDocumentation();
+
         var totalTime = now()-start;
 
         //and a quick report with some padding at the bottom


### PR DESCRIPTION
the method `endGenerateDocumentation` existed but was not being called, the result being (at least, the result for me, perhaps it affects other usages too) that when grunt-docular uses docular, the callback never gets run and so the grunt build effectively 'exits' after running the grunt-docular task.

i raised this as an issue in the grunt-docular project:

https://github.com/gitsome/grunt-docular/issues/6

before i tracked it down to here.
