### PR TITLE
Allow <docType>Of merging - useful for plugins

### DIFF
--- a/lib/scripts/doc_utils.js
+++ b/lib/scripts/doc_utils.js
@@ -180,7 +180,8 @@ function merge(docs){
 
     // merge into parents by removing it from the root list
     // the find parent method will add it to a nested list for each parent found
-    if (findParent(doc, 'method') || findParent(doc, 'property') || findParent(doc, 'event')) {
+    if (findParent(doc, 'method') || findParent(doc, 'property') || 
+      findParent(doc, 'event') || findParent(doc, doc.docType)) {
       docs.splice(i, 1);
     } else {
       i++;


### PR DESCRIPTION
Allowed merging for custom <docType>Of, useful for plugins. Previously limited to methodOf, propertyOf and eventOf. For example, for a plugin I may create a new docType (e.g. path) which needs to be merged with a parent. 

With this change you can now automatically use the merge functionality as long as the docType matches the <docType>Of.
