### PR TITLE
Replace all calls to writer.js (fixes #97)

### DIFF
--- a/lib/scripts/gen-docs.js
+++ b/lib/scripts/gen-docs.js
@@ -38,6 +38,7 @@ var reader = require('./reader.js'),
     Q = require('q'),
     qfs = require('q-fs'),
     fs = require('fs'),
+    fse = require('fs-extra'),
     path = require('path'),
     nodeExtend = require('node.extend'),
     colors = require('colors');
@@ -428,7 +429,7 @@ var generate = function (options_in, callBack) {
     Q.when(loadConfiguredPlugins(), function(content) {}).then(function (){
 
         //then make sure we have the target webapp directory created
-        return writer.makeDir(ABS_WEBAPP, false);
+        return fse.mkdirsSync(ABS_WEBAPP, false);
 
 
     }).then(function () {
@@ -707,8 +708,8 @@ var generate = function (options_in, callBack) {
                         var jsControllerDir = REL_LIB + '/nodeserver/controller/' + plugin + '/' + controllerName + '/';
 
                         //create node and php controller directories
-                        writer.makeDir(jsControllerDir, true);
-                        writer.makeDir(phpControllerDir, true);
+                        fse.mkdirsSync(jsControllerDir, true);
+                        fse.mkdirsSync(phpControllerDir, true);
 
                         //copy the node controller
                         var cPromise = Q.when(function(){
@@ -771,7 +772,7 @@ var generate = function (options_in, callBack) {
         //now we generate the php config file the node config file and client config file
         var jsServerConfigsTarget = REL_LIB + '/nodeserver/configs/configs.js';
 
-        writer.makeDir(REL_LIB + '/nodeserver/configs/');
+        fse.mkdirsSync(REL_LIB + '/nodeserver/configs/');
         var jsServerConfigsPromise = writer.output(jsServerConfigsTarget,["exports.configs=" + JSON.stringify(serverConfigs)]);
 
         pluginPromises.push(jsServerConfigsPromise);
@@ -871,7 +872,7 @@ var generate = function (options_in, callBack) {
 
             return Q.all(copyPromises).then(function(){
 
-                writer.makeDir(REL_WEBAPP + '/resources/doc_api_resources/', true);
+                fse.mkdirsSync(REL_WEBAPP + '/resources/doc_api_resources/', true);
 
                 var uiPromises = [];
 

--- a/lib/scripts/writer.js
+++ b/lib/scripts/writer.js
@@ -6,6 +6,7 @@ var qfs = require('q-io/fs');
 var Q = require('q');
 var OUTPUT_DIR = '';
 var fs = require('fs');
+var fse = require('fs-extra');
 var path = require('path');
 var qio = require('q-io/fs');
 
@@ -14,41 +15,8 @@ exports.output = output;
 function output(file, content) {
     var fullPath = OUTPUT_DIR + file;
     var dir = parent(fullPath);
-    exports.makeDir(dir);
+    fse.mkdirsSync(dir); 
     return qfs.write(fullPath, exports.toString(content));
-};
-
-//recursively create directory
-exports.makeDir = function(p, relative) {
-
-    var parts = p.split(/\//);
-    var path = relative ? "." : "";
-
-    var checkExists = function (pt) {
-        return fs.existsSync(pt);
-    };
-
-    var createPart = function (exists) {
-
-        if(!exists && parts.length) {
-            path += "/" + parts.shift();
-            var pathExists = checkExists(path);
-            if (!pathExists) {
-                try {
-                    fs.mkdirSync(path);
-                    createPart(true);
-                } catch (e) {
-                    createPart();
-                }
-            } else {
-                createPart();
-            }
-        }
-    };
-
-    // Recursively rebuild directory structure
-    createPart(checkExists(p));
-    return true;
 };
 
 exports.copyTemplate = function(filename) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "q": "*",
     "node.extend": "*",
     "express": "*",
-    "request": "*"
+    "request": "*",
+    "fs-extra":"*"
   },
   "keywords": [
     "angular",


### PR DESCRIPTION
Use fs-extra's mkdirsSync function instead of writer.js' makeDir, which silently fails on my system causing configs.js to not be written (see issue).

This addresses https://github.com/gitsome/docular/issues/97
