### PR TITLE
package.json: limit express version to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "q-io":"1.9.4",
     "q": "*",
     "node.extend": "*",
-    "express": "*",
+    "express": "3.x",
     "request": "*"
   },
   "keywords": [


### PR DESCRIPTION
Change the version specifier for the dependency `express` to `3.x`,
to preven npm from installing 4.x versions. The docular nodeserver
does not work with express 4.x.

Close #97
Close #99
Close gitsome/grunt-docular#13

@gitsome Could you please review and release a patch version ASAP?

BTW I realise it would be better to upgrade docular to work with express 4.x. However, I don't have time to submit that change. This patch, even if it may not be the perfect solution, is at least fixing the critical issue of docular server not working at all.
