### PR TITLE
Add missing null checks to prevent crashes on page changes

### DIFF
--- a/lib/webapp/resources/js/docs_module_begin.js
+++ b/lib/webapp/resources/js/docs_module_begin.js
@@ -560,23 +560,32 @@ docsApp.controller.DocsController = function($scope, $location, $window, $cookie
                 var sectionName = sectionId ? sections.groupMap[groupId].sections[sectionId].title : "";
 
                 //determine if we have already loaded this page
-                var pageAlreadyLoaded = $scope.currentPage && $scope.currentPage.partialUrl ? (page.partialUrl == $scope.currentPage.partialUrl ? true : false) : false;
+                var pageAlreadyLoaded = false;
+                if ($scope.currentPage) {
+                    if ($scope.currentPage.partialUrl){
+                        if (page){
+                            pageAlreadyLoaded = page.partialUrl === $scope.currentPage.partialUrl;
+                        }
+                    }
+                }
+                
                 if(pageAlreadyLoaded){
                     $scope.loading = contentLoading.endLoading();
                 }
 
                 $scope.currentPage = page;
 
-                $scope.currentSource = {
-                    source: $scope.currentPage.source,
-                    codeBlocks: $scope.currentPage.codeBlocks
-                };
+        
 
                 if (!$scope.currentPage) {
                     $scope.partialTitle = 'Error: Page Not Found!';
                 } else {
+                    $scope.currentSource = {
+                        source: $scope.currentPage.source,
+                        codeBlocks: $scope.currentPage.codeBlocks
+                    };
 
-                    //lets expose additional data into the $scope so extensions can take advanatage of it
+                    //lets expose additional data into the $scope so extensions can take advantage of it
                     $scope.sectionInfo = sections.groupMap[groupId].sections[sectionId];
                     var pageOrder = $scope.sectionInfo.rank || {};
                     $scope.sectionPages = sortPages(sections.pages[groupId][sectionId], pageOrder);


### PR DESCRIPTION
Added missing null checks in docs_module_begin to avoid issues with page...s that are missing documentation.

This is an issue if no index is supplied since it will cause docular to crash on changing categories.
Simplified page already loaded logic and added a missing null check there.
This is an enhancement of pull request #85 without the windows compatibility fix.
