### PR TITLE
Bower configuration file in the config install options fix #117

### DIFF
--- a/lib/scripts/core/dependencyHandler.js
+++ b/lib/scripts/core/dependencyHandler.js
@@ -9,14 +9,12 @@ module.exports = {
     loadDependencies: function (dependencies) {
         var deferred = Q.defer();
         
-        bower.config.cwd = bowerDumpPath;
-        
         bower.commands.install(dependencies.map(function (item) {
             if(item.version) {
                 return item.package + "#" + item.version;
             }
             return item.package;
-        }))
+        }), {}, {cwd: bowerDumpPath, dir: 'bower_components'})
         .on('error', function (err) {
             deferred.reject(err);
         })


### PR DESCRIPTION
http://bower.io/docs/api/#programmatic-api - see the custom config after
options
Adds dir config option to override .bowerrc configuration

Fix #117 
