### PR TITLE
Implementation of showSource option

### DIFF
--- a/lib/resources/js/controllers/index.js
+++ b/lib/resources/js/controllers/index.js
@@ -123,19 +123,21 @@ angular.module('docular.controllers', [
             if(!documentationItem) {
                 $scope.isIndex = true;
             } else {
-                sourceService.fetchSourceFile(documentationItem.file).then(function (resp) {
-                    var fileType = fileType ? documentationItem.file.match(/[A-Za-z0-9]+$/) : null;
-                    if(fileType && fileType.length == 1) {
-                        fileType = fileType[0];
-                    } else {
-                        fileType = null;
-                    }
-                    $scope.source = {
-                        content: resp.data,
-                        fileType: fileType
-                    }
-                    console.log($scope.source);
-                });
+                if (documentationItem.showSource) {
+                    sourceService.fetchSourceFile(documentationItem.file).then(function (resp) {
+                        var fileType = fileType ? documentationItem.file.match(/[A-Za-z0-9]+$/) : null;
+                        if(fileType && fileType.length == 1) {
+                            fileType = fileType[0];
+                        } else {
+                            fileType = null;
+                        }
+                        $scope.source = {
+                            content: resp.data,
+                            fileType: fileType
+                        }
+                        console.log($scope.source);
+                    });
+                }
 
                 $scope.includeUrl = 'resources/plugins/' + documentationItem.handler + '/documentationPartial.html';
             }

--- a/lib/resources/templates/index_page.html
+++ b/lib/resources/templates/index_page.html
@@ -43,7 +43,7 @@
                     </ul>
                 </div>
             </div>
-            <button ng-if="documentationItem && viewing!='source'" id='showSourceButton' ng-click="toggleSource()">Show Source</button>
+            <button ng-if="documentationItem && documentationItem.showSource && viewing!='source'" id='showSourceButton' ng-click="toggleSource()">Show Source</button>
             <button ng-if="documentationItem && viewing=='source'" id='hideSourceButton' ng-click="toggleSource()">Show Docs</button>
             <ng-include autoscroll="true" src="includeUrl" ng-if="documentationItem && viewing !='source'"> </ng-include>
             <source-viewer ng-if="viewing=='source'" source="source.content" file-type="{{source.fileType}}"></source-viewer>

--- a/lib/scripts/core/generator.js
+++ b/lib/scripts/core/generator.js
@@ -125,11 +125,20 @@ var Generator = Group.extend({
             fs.writeFileSync(baseFolder + '/site.json', JSON.stringify(docs, null, 4));
             fs.writeFileSync(baseFolder + '/structure.json', JSON.stringify(structure, null, 4));
 
-            fse.ensureDirSync(baseFolder + '/sources/');
+            var bSourcesFolderCreated = false;
+
             for (var i = 0, l = docs.length; i < l; i++) {
-                if (docs[i].file) {
+                if (docs[i].file && docs[i].showSource) {
+                    
+                    //We only create the sources folder if it's needed by at least one file
+                    if (!bSourcesFolderCreated) {
+                        bSourcesFolderCreated = true;
+                        fse.ensureDirSync(baseFolder + '/sources/');
+                    }
+                    
                     fse.ensureFileSync(baseFolder + '/sources/' + docs[i].file);
                     fse.copySync(docs[i].file, baseFolder + '/sources/' + docs[i].file);
+                    
                 }
             }
 

--- a/lib/scripts/core/group.js
+++ b/lib/scripts/core/group.js
@@ -221,11 +221,7 @@ var Group = Class.extend({
     },
 
     buildRegistry: function () {
-        var bShowSource = this.option('showSource');
         this.docs.forEach(function (doc) {
-            if (!bShowSource && doc.file) {
-                delete doc.file;
-            }
             this.registry.addItem(doc.id, doc);
         }.bind(this));
         return this.runRecursively('buildRegistry');

--- a/lib/scripts/core/group.js
+++ b/lib/scripts/core/group.js
@@ -75,18 +75,20 @@ var Group = Class.extend({
         return paths.reverse().join('/');
     },
 
-    setupGroups: function () {
+    setupGroups: function (parentConfig) {
+        // The root group isn't called with a parentConfig so we set default value of bShowSource at this point
+        var _parentConfig = parentConfig || {showSource : false};
         var groups = this.option('groups');
         var self = this;
         this._groups = [];
         if(!groups) { return; }
         for(var i = 0, l = groups.length; i < l; i++) {
-            var config = Group.normalizeConfig(groups[i]);
+            var config = Group.normalizeConfig(groups[i], _parentConfig);
             this.emit('ProcessGroupConfig', config);
             var group = new Group(config, {
                 registry: this.registry
             });
-            group.setupGroups();
+            group.setupGroups(config);
             this.events.forEach(function (evt) {
                 group.on(evt, function () {
                     self.emit.apply(self, [evt].concat(Array.prototype.slice.apply(arguments)));
@@ -193,6 +195,7 @@ var Group = Class.extend({
         var promises = [];
         var self = this;
         var files = this.option('files') || [];
+        var showSource = this.option('showSource');
         this.docs = [];
 
         files.forEach(function (fileName) {
@@ -207,6 +210,7 @@ var Group = Class.extend({
                 }
                 docPromise.then(function (docModel) {
                     docModel.setPath(paths);
+                    docModel.data.showSource = showSource;
                     self.docs.push(docModel);
                     docModel.groupId = self.internalGroupId;
                     self.files[fileName].docs.push(docModel);
@@ -222,12 +226,13 @@ var Group = Class.extend({
 
     buildRegistry: function () {
         this.docs.forEach(function (doc) {
-            this.registry.addItem(doc.id, doc);
+            this.registry.addItem(doc.id, doc);            
         }.bind(this));
+                
         return this.runRecursively('buildRegistry');
     }
 }, {
-    normalizeConfig: function (groupData) {
+    normalizeConfig: function (groupData, parentGroupData) {
         /*
          * Backwards compatibility
          */
@@ -236,6 +241,10 @@ var Group = Class.extend({
         }
         if(!groupData.groupIcon) {
             groupData.groupIcon = 'code';
+        }
+        // If we don't explicitly set showSource, we inherit from parent
+        if (typeof(groupData.showSource) !== 'boolean') {
+            groupData.showSource = parentGroupData.showSource;   
         }
 
         return groupData;

--- a/lib/scripts/core/group.js
+++ b/lib/scripts/core/group.js
@@ -221,7 +221,11 @@ var Group = Class.extend({
     },
 
     buildRegistry: function () {
+        var bShowSource = this.option('showSource');
         this.docs.forEach(function (doc) {
+            if (!bShowSource && doc.file) {
+                delete doc.file;
+            }
             this.registry.addItem(doc.id, doc);
         }.bind(this));
         return this.runRecursively('buildRegistry');


### PR DESCRIPTION
The pages http://grunt-docular.com/documentation/docular/docularconfigure/groups (404 when navigating directly and not from index btw) or https://github.com/Vertafore/docular/blob/master/lib/scripts/docs/configure/configure.md
states the following :

> `showSource` – `{boolean}` –
> Defaults to false. When true will copy all source files to the webapp so they can be displayed in the UI. WARNING All files within this group should be considered public. All information should be considered insecure. Note, you can set the 'showSource' configuration at the section level to override the group level setting

However, when we look at the original code of docular, at least at commit https://github.com/Vertafore/docular/commit/567d35d0b3f4f13b2bc3ee5ac3c8fc2cebd09e67 we don't see it being used.
The code copies all source files and the angular template always has the showSource button enabled.

Maybe the feature was implemented in the past and removed at some point. But I find it very handy.
I have therefore prepared a code change where the showSource option is inherited (if not defined) and properly used both during copy of the source files to the "sources" folder and also taken care of properly in the angular template.
