### PR TITLE
Fix dropdown menu width

### DIFF
--- a/lib/resources/less/docular.less
+++ b/lib/resources/less/docular.less
@@ -82,9 +82,6 @@ and open the template in the editor.
     left: 0px;
     top: 100%;
     width: 100%;
-    ul {
-        width: 100%;
-    }
 }
 
 .dd-menu {


### PR DESCRIPTION
“width: 100%;” on the dropdown menu relates to it’s parent which is the
title li. This constrains the dropdown menu’s width and creates an
overflow in the very likely situation that the names of the items in
the list are longer than the parent’s width.
