### PR TITLE
Fix file type not being set properly for viewing source documents

### DIFF
--- a/lib/resources/js/controllers/index.js
+++ b/lib/resources/js/controllers/index.js
@@ -124,7 +124,7 @@ angular.module('docular.controllers', [
                 $scope.isIndex = true;
             } else {
                 sourceService.fetchSourceFile(documentationItem.file).then(function (resp) {
-                    var fileType = fileType ? documentationItem.file.match(/[A-Za-z0-9]+$/) : null;
+                    var fileType = documentationItem.file.match(/[A-Za-z0-9]+$/);
                     if(fileType && fileType.length == 1) {
                         fileType = fileType[0];
                     } else {
@@ -133,7 +133,7 @@ angular.module('docular.controllers', [
                     $scope.source = {
                         content: resp.data,
                         fileType: fileType
-                    }
+                    };
                     console.log($scope.source);
                 });
 


### PR DESCRIPTION
File type was always being set to null as it was coded. Updated to allow the regex match to always run.
